### PR TITLE
watch metricUrl scope attribute instread of dataUrl internal value

### DIFF
--- a/src/chart/hawkular-chart-directive.ts
+++ b/src/chart/hawkular-chart-directive.ts
@@ -1697,7 +1697,7 @@ module Charts {
           }
 
           /// standalone charts attributes
-          scope.$watchGroup(['dataUrl', 'metricId', 'metricTenantId', 'timeRangeInSeconds'], (standAloneParams) => {
+          scope.$watchGroup(['metricUrl', 'metricId', 'metricTenantId', 'timeRangeInSeconds'], (standAloneParams) => {
             ///$log.debug('standalone params has changed');
             dataUrl = standAloneParams[0];
             metricId = standAloneParams[1];


### PR DESCRIPTION
This fixes an issue with metric-url attribute not being watched
