### PR TITLE
Cancel interval on directive destroy and anytime new interval is crea…

### DIFF
--- a/src/chart/hawkular-chart-directive.ts
+++ b/src/chart/hawkular-chart-directive.ts
@@ -143,6 +143,8 @@ module Charts {
           annotationData = attrs.annotationData;
           contextData = attrs.contextData;
 
+          var startIntervalPromise;
+
           function xMidPointStartPosition(d) {
             return timeScale(d.timestamp) + (calcBarWidth() / 2);
           }
@@ -1709,10 +1711,15 @@ module Charts {
           scope.$watch('refreshIntervalInSeconds', (newRefreshInterval) => {
             if (newRefreshInterval) {
               refreshIntervalInSeconds = +newRefreshInterval;
-              var startIntervalPromise = $interval(() => {
+              $interval.cancel(startIntervalPromise);
+              startIntervalPromise = $interval(() => {
                 loadStandAloneMetricsTimeRangeFromNow();
               }, refreshIntervalInSeconds * 1000);
             }
+          });
+
+          scope.$on('$destroy', () => {
+            $interval.cancel(startIntervalPromise);
           });
 
           scope.$on('DateRangeDragChanged', (event, extent) => {


### PR DESCRIPTION
…ted.

This fixes 2 issues with refreshInterval.
- when directive was destroyed it continued to load data - directive did not $interval.cancel $on('$destroy')
- when refreshInterval changed, (ie from 5 to 60s) directive was still loading data every 5s, but also every 60s - the original interval was not cleared out. 
