### PR TITLE
Fix situation when there's data from the future

### DIFF
--- a/hawkular-charts.js
+++ b/hawkular-charts.js
@@ -154,6 +154,10 @@ var Charts;
                             var i;
                             backwardsEndTime = now;
                             for (i = inAvailData.length; i > 0; i--) {
+                                // if we have data starting in the future... discard it
+                                if (inAvailData[i - 1].timestamp > +moment()) {
+                                    continue;
+                                }
                                 if (startTimestamp >= inAvailData[i - 1].timestamp) {
                                     outputData.push(new TransformedAvailDataPoint(startTimestamp, backwardsEndTime, inAvailData[i - 1].value));
                                     break;

--- a/src/chart/avail-chart-directive.ts
+++ b/src/chart/avail-chart-directive.ts
@@ -228,6 +228,10 @@ namespace Charts {
 
             backwardsEndTime = now;
             for (i = inAvailData.length; i > 0; i--) {
+              // if we have data starting in the future... discard it
+              if(inAvailData[i - 1].timestamp > +moment()) {
+                continue;
+              }
               if(startTimestamp >= inAvailData[i - 1].timestamp) {
                 outputData.push(new TransformedAvailDataPoint(startTimestamp, backwardsEndTime, inAvailData[i - 1].value));
                 break;


### PR DESCRIPTION
When the charts are provided data in the future, the whole data (not
respecting scale and startTimestamp was being shown, due to issues with
date range calculation). This fixes it by discarding chunks which are
starting in the future.
