### PR TITLE
Enable BrowserSync for live reload across browsers

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -31,6 +31,7 @@ var gulp = require('gulp'),
   merge = require('merge2'),
   uglify = require('gulp-uglify'),
   gutil = require('gulp-util'),
+  browsersync = require('browser-sync'),
   tslint = require('gulp-tslint');
 
 var plugins = gulpLoadPlugins({});
@@ -39,6 +40,7 @@ var pkg = require('./package.json');
 var config = {
   main: '.',
   ts: ['src/**/*.ts'],
+  css: ['css/*.css'],
   dist: './dist/',
   js: pkg.name + '.js',
   tsProject: plugins.typescript.createProject({
@@ -116,6 +118,14 @@ gulp.task('tslint', function () {
     .pipe(tslint.report('verbose'));
 });
 
+gulp.task('browsersync', function(callback) {
+  return browsersync({
+    server: {
+      baseDir:'./'
+    }
+  }, callback);
+});
+
 
 gulp.task('concat', function () {
   var gZipSize = size(gZippedSizeOptions);
@@ -130,14 +140,17 @@ gulp.task('clean', ['concat'], function () {
     .pipe(plugins.clean());
 });
 
+gulp.task('dev-build', ['bower', 'path-adjust', 'tslint', 'tsc', 'concat', 'clean']);
+
 gulp.task('watch', function () {
-  gulp.watch(config.ts, ['build']);
+  gulp.watch(config.css, ['dev-build', browsersync.reload]);
+  gulp.watch(config.js, ['dev-build', browsersync.reload]);
 });
 
 
 gulp.task('build', ['bower', 'path-adjust', 'tslint', 'tsc', 'concat', 'clean']);
-
-gulp.task('default', ['build']);
+//gulp.task('default', gulp.parallel('bower', 'path-adjust','tslint','tsc','concat', 'browsersync', 'watch'));
+gulp.task('default', ['watch']);
 
 
 

--- a/index.html
+++ b/index.html
@@ -1,0 +1,1367 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>Hawkular Chart Tester</title>
+  <meta name="description"
+        content="Hawkular Charts Standalone Chart Example. An example how to use the hawkular-charts in a sample page.">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="css/hawkular-charts.css">
+  <style>
+    .metricIdLabel {
+      color: darkred;
+    }
+
+    .metricIdHeader {
+      margin: 20px 0 -45px 90px;
+    }
+
+    .metricIdHeader > li {
+      margin-left: 40px;
+    }
+
+    .itemDescription {
+      color: #999;
+      font-style: italic;
+    }
+
+    .chartWrapper {
+      height: 250px;
+    }
+  </style>
+
+  <!-- build:js scripts/vendor.js -->
+  <!-- bower:js -->
+  <script src="libs/jquery/dist/jquery.js"></script>
+  <script src="libs/angular/angular.js"></script>
+  <script src="libs/d3/d3.js"></script>
+  <script src="libs/moment/moment.js"></script>
+  <script src="libs/d3-tip/index.js"></script>
+  <!-- endbower -->
+  <!-- endbuild -->
+
+  <!-- build:js({.tmp,app}) scripts/scripts.js -->
+  <!-- endbuild -->
+
+
+  <script>
+    var app = angular.module('myApp', ['hawkular.charts']);
+
+    app.controller('ChartController', function ($scope) {
+      //var self = this;
+
+      // set the alert threshold to whatever
+      $scope.alertThreshold = 2000;
+
+
+      // A captured Hawkular Feed for sample data -- simulates loading data
+      $scope.myData = [{
+        "timestamp": 1434476761167,
+        "date": "2015-06-16T17:46:01.167Z",
+        "value": 0,
+        "avg": 1912,
+        "min": 1482,
+        "max": 2342,
+        "percentile95th": 2342,
+        "median": 1912,
+        "empty": false
+      }, {
+        "timestamp": 1434476791167,
+        "date": "2015-06-16T17:46:31.167Z",
+        "value": 0,
+        "avg": 1816,
+        "min": 1816,
+        "max": 1816,
+        "percentile95th": 1816,
+        "median": 1816,
+        "empty": false
+      }, {
+        "timestamp": 1434476821167,
+        "date": "2015-06-16T17:47:01.167Z",
+        "value": 0,
+        "avg": 1943.5,
+        "min": 1747,
+        "max": 2140,
+        "percentile95th": 2140,
+        "median": 1943.5,
+        "empty": false
+      }, {
+        "timestamp": 1434476851167,
+        "date": "2015-06-16T17:47:31.167Z",
+        "value": 0,
+        "avg": 1770,
+        "min": 1770,
+        "max": 1770,
+        "percentile95th": 1770,
+        "median": 1770,
+        "empty": false
+      }, {
+        "timestamp": 1434476881167,
+        "date": "2015-06-16T17:48:01.167Z",
+        "value": 0,
+        "avg": 1943.5,
+        "min": 1858,
+        "max": 2029,
+        "percentile95th": 2029,
+        "median": 1943.5,
+        "empty": false
+      }, {
+        "timestamp": 1434476911167,
+        "date": "2015-06-16T17:48:31.167Z",
+        "value": 0,
+        "avg": 2139,
+        "min": 2139,
+        "max": 2139,
+        "percentile95th": 2139,
+        "median": 2139,
+        "empty": false
+      }, {
+        "timestamp": 1434476941167,
+        "date": "2015-06-16T17:49:01.167Z",
+        "value": 0,
+        "avg": 2160,
+        "min": 1899,
+        "max": 2421,
+        "percentile95th": 2421,
+        "median": 2160,
+        "empty": false
+      }, {
+        "timestamp": 1434476971167,
+        "date": "2015-06-16T17:49:31.167Z",
+        "value": 0,
+        "avg": 1753,
+        "min": 1753,
+        "max": 1753,
+        "percentile95th": 1753,
+        "median": 1753,
+        "empty": false
+      }, {
+        "timestamp": 1434477001167,
+        "date": "2015-06-16T17:50:01.167Z",
+        "value": 0,
+        "avg": 1813.5,
+        "min": 1804,
+        "max": 1823,
+        "percentile95th": 1823,
+        "median": 1813.5,
+        "empty": false
+      }, {
+        "timestamp": 1434477031167,
+        "date": "2015-06-16T17:50:31.167Z",
+        "value": 0,
+        "avg": 2119,
+        "min": 2119,
+        "max": 2119,
+        "percentile95th": 2119,
+        "median": 2119,
+        "empty": false
+      }, {
+        "timestamp": 1434477061167,
+        "date": "2015-06-16T17:51:01.167Z",
+        "value": 0,
+        "avg": 1693,
+        "min": 1632,
+        "max": 1754,
+        "percentile95th": 1754,
+        "median": 1693,
+        "empty": false
+      }, {
+        "timestamp": 1434477091167,
+        "date": "2015-06-16T17:51:31.167Z",
+        "value": 0,
+        "avg": 1921,
+        "min": 1921,
+        "max": 1921,
+        "percentile95th": 1921,
+        "median": 1921,
+        "empty": false
+      }, {
+        "timestamp": 1434477121167,
+        "date": "2015-06-16T17:52:01.167Z",
+        "value": 0,
+        "avg": 2077,
+        "min": 1629,
+        "max": 2525,
+        "percentile95th": 2525,
+        "median": 2077,
+        "empty": false
+      }, {
+        "timestamp": 1434477151167,
+        "date": "2015-06-16T17:52:31.167Z",
+        "value": 0,
+        "avg": 1715,
+        "min": 1715,
+        "max": 1715,
+        "percentile95th": 1715,
+        "median": 1715,
+        "empty": false
+      }, {
+        "timestamp": 1434477181167,
+        "date": "2015-06-16T17:53:01.167Z",
+        "value": 0,
+        "avg": 1682,
+        "min": 1552,
+        "max": 1812,
+        "percentile95th": 1812,
+        "median": 1682,
+        "empty": false
+      }, {
+        "timestamp": 1434477211167,
+        "date": "2015-06-16T17:53:31.167Z",
+        "value": 0,
+        "avg": 1510,
+        "min": 1510,
+        "max": 1510,
+        "percentile95th": 1510,
+        "median": 1510,
+        "empty": false
+      }, {
+        "timestamp": 1434477241167,
+        "date": "2015-06-16T17:54:01.167Z",
+        "value": 0,
+        "avg": 1774,
+        "min": 1631,
+        "max": 1917,
+        "percentile95th": 1917,
+        "median": 1774,
+        "empty": false
+      }, {
+        "timestamp": 1434477271167,
+        "date": "2015-06-16T17:54:31.167Z",
+        "value": 0,
+        "avg": 1790,
+        "min": 1790,
+        "max": 1790,
+        "percentile95th": 1790,
+        "median": 1790,
+        "empty": false
+      }, {
+        "timestamp": 1434477301167,
+        "date": "2015-06-16T17:55:01.167Z",
+        "value": 0,
+        "avg": 1977.5,
+        "min": 1808,
+        "max": 2147,
+        "percentile95th": 2147,
+        "median": 1977.5,
+        "empty": false
+      }, {
+        "timestamp": 1434477331167,
+        "date": "2015-06-16T17:55:31.167Z",
+        "value": 0,
+        "avg": 1813,
+        "min": 1813,
+        "max": 1813,
+        "percentile95th": 1813,
+        "median": 1813,
+        "empty": false
+      }, {
+        "timestamp": 1434477361167,
+        "date": "2015-06-16T17:56:01.167Z",
+        "value": 0,
+        "avg": 1729.5,
+        "min": 1667,
+        "max": 1792,
+        "percentile95th": 1792,
+        "median": 1729.5,
+        "empty": false
+      }, {
+        "timestamp": 1434477391167,
+        "date": "2015-06-16T17:56:31.167Z",
+        "value": 0,
+        "avg": 1928,
+        "min": 1928,
+        "max": 1928,
+        "percentile95th": 1928,
+        "median": 1928,
+        "empty": false
+      }, {
+        "timestamp": 1434477421167,
+        "date": "2015-06-16T17:57:01.167Z",
+        "value": 0,
+        "avg": 1721,
+        "min": 1687,
+        "max": 1755,
+        "percentile95th": 1755,
+        "median": 1721,
+        "empty": false
+      }, {
+        "timestamp": 1434477451167,
+        "date": "2015-06-16T17:57:31.167Z",
+        "value": 0,
+        "avg": 1783,
+        "min": 1783,
+        "max": 1783,
+        "percentile95th": 1783,
+        "median": 1783,
+        "empty": false
+      }, {
+        "timestamp": 1434477481167,
+        "date": "2015-06-16T17:58:01.167Z",
+        "value": 0,
+        "avg": 1935.5,
+        "min": 1843,
+        "max": 2028,
+        "percentile95th": 2028,
+        "median": 1935.5,
+        "empty": false
+      }, {
+        "timestamp": 1434477511167,
+        "date": "2015-06-16T17:58:31.167Z",
+        "value": 0,
+        "avg": 1736,
+        "min": 1736,
+        "max": 1736,
+        "percentile95th": 1736,
+        "median": 1736,
+        "empty": false
+      }, {
+        "timestamp": 1434477541167,
+        "date": "2015-06-16T17:59:01.167Z",
+        "value": 0,
+        "avg": 1776,
+        "min": 1619,
+        "max": 1933,
+        "percentile95th": 1933,
+        "median": 1776,
+        "empty": false
+      }, {
+        "timestamp": 1434477571167,
+        "date": "2015-06-16T17:59:31.167Z",
+        "value": 0,
+        "avg": 1640,
+        "min": 1640,
+        "max": 1640,
+        "percentile95th": 1640,
+        "median": 1640,
+        "empty": false
+      }, {
+        "timestamp": 1434477601167,
+        "date": "2015-06-16T18:00:01.167Z",
+        "value": 0,
+        "avg": 1731.5,
+        "min": 1662,
+        "max": 1801,
+        "percentile95th": 1801,
+        "median": 1731.5,
+        "empty": false
+      }, {
+        "timestamp": 1434477631167,
+        "date": "2015-06-16T18:00:31.167Z",
+        "value": 0,
+        "avg": 1683,
+        "min": 1683,
+        "max": 1683,
+        "percentile95th": 1683,
+        "median": 1683,
+        "empty": false
+      }, {
+        "timestamp": 1434477661167,
+        "date": "2015-06-16T18:01:01.167Z",
+        "value": 0,
+        "avg": 2112.5,
+        "min": 1945,
+        "max": 2280,
+        "percentile95th": 2280,
+        "median": 2112.5,
+        "empty": false
+      }, {
+        "timestamp": 1434477691167,
+        "date": "2015-06-16T18:01:31.167Z",
+        "value": 0,
+        "avg": 1952,
+        "min": 1952,
+        "max": 1952,
+        "percentile95th": 1952,
+        "median": 1952,
+        "empty": false
+      }, {
+        "timestamp": 1434477721167,
+        "date": "2015-06-16T18:02:01.167Z",
+        "value": 0,
+        "avg": 1587.5,
+        "min": 1497,
+        "max": 1678,
+        "percentile95th": 1678,
+        "median": 1587.5,
+        "empty": false
+      }, {
+        "timestamp": 1434477751167,
+        "date": "2015-06-16T18:02:31.167Z",
+        "value": 0,
+        "avg": 1889,
+        "min": 1889,
+        "max": 1889,
+        "percentile95th": 1889,
+        "median": 1889,
+        "empty": false
+      }, {
+        "timestamp": 1434477781167,
+        "date": "2015-06-16T18:03:01.167Z",
+        "value": 0,
+        "avg": 1920,
+        "min": 1753,
+        "max": 2087,
+        "percentile95th": 2087,
+        "median": 1920,
+        "empty": false
+      }, {
+        "timestamp": 1434477811167,
+        "date": "2015-06-16T18:03:31.167Z",
+        "value": 0,
+        "avg": 1773,
+        "min": 1773,
+        "max": 1773,
+        "percentile95th": 1773,
+        "median": 1773,
+        "empty": false
+      }, {
+        "timestamp": 1434477841167,
+        "date": "2015-06-16T18:04:01.167Z",
+        "value": 0,
+        "avg": 1750.5,
+        "min": 1618,
+        "max": 1883,
+        "percentile95th": 1883,
+        "median": 1750.5,
+        "empty": false
+      }, {
+        "timestamp": 1434477871167,
+        "date": "2015-06-16T18:04:31.167Z",
+        "value": 0,
+        "avg": 1681,
+        "min": 1681,
+        "max": 1681,
+        "percentile95th": 1681,
+        "median": 1681,
+        "empty": false
+      }, {
+        "timestamp": 1434477901167,
+        "date": "2015-06-16T18:05:01.167Z",
+        "value": 0,
+        "avg": 1789,
+        "min": 1638,
+        "max": 1940,
+        "percentile95th": 1940,
+        "median": 1789,
+        "empty": false
+      }, {
+        "timestamp": 1434477931167,
+        "date": "2015-06-16T18:05:31.167Z",
+        "value": 0,
+        "avg": 1677,
+        "min": 1677,
+        "max": 1677,
+        "percentile95th": 1677,
+        "median": 1677,
+        "empty": false
+      }, {
+        "timestamp": 1434477961167,
+        "date": "2015-06-16T18:06:01.167Z",
+        "value": 0,
+        "avg": 1711,
+        "min": 1662,
+        "max": 1760,
+        "percentile95th": 1760,
+        "median": 1711,
+        "empty": false
+      }, {
+        "timestamp": 1434477991167,
+        "date": "2015-06-16T18:06:31.167Z",
+        "value": 0,
+        "avg": 1812,
+        "min": 1812,
+        "max": 1812,
+        "percentile95th": 1812,
+        "median": 1812,
+        "empty": false
+      }, {
+        "timestamp": 1434478021167,
+        "date": "2015-06-16T18:07:01.167Z",
+        "value": 0,
+        "avg": 1784,
+        "min": 1748,
+        "max": 1820,
+        "percentile95th": 1820,
+        "median": 1784,
+        "empty": false
+      }, {
+        "timestamp": 1434478051167,
+        "date": "2015-06-16T18:07:31.167Z",
+        "value": 0,
+        "avg": 1650,
+        "min": 1650,
+        "max": 1650,
+        "percentile95th": 1650,
+        "median": 1650,
+        "empty": false
+      }, {
+        "timestamp": 1434478081167,
+        "date": "2015-06-16T18:08:01.167Z",
+        "value": 0,
+        "avg": 1617.5,
+        "min": 1577,
+        "max": 1658,
+        "percentile95th": 1658,
+        "median": 1617.5,
+        "empty": false
+      }, {
+        "timestamp": 1434478111167,
+        "date": "2015-06-16T18:08:31.167Z",
+        "value": 0,
+        "avg": 1618,
+        "min": 1618,
+        "max": 1618,
+        "percentile95th": 1618,
+        "median": 1618,
+        "empty": false
+      }, {
+        "timestamp": 1434478141167,
+        "date": "2015-06-16T18:09:01.167Z",
+        "value": 0,
+        "avg": 1721.5,
+        "min": 1714,
+        "max": 1729,
+        "percentile95th": 1729,
+        "median": 1721.5,
+        "empty": false
+      }, {
+        "timestamp": 1434478171167,
+        "date": "2015-06-16T18:09:31.167Z",
+        "value": 0,
+        "avg": 1762,
+        "min": 1762,
+        "max": 1762,
+        "percentile95th": 1762,
+        "median": 1762,
+        "empty": false
+      }, {
+        "timestamp": 1434478201167,
+        "date": "2015-06-16T18:10:01.167Z",
+        "value": 0,
+        "avg": 1768.5,
+        "min": 1607,
+        "max": 1930,
+        "percentile95th": 1930,
+        "median": 1768.5,
+        "empty": false
+      }, {
+        "timestamp": 1434478231167,
+        "date": "2015-06-16T18:10:31.167Z",
+        "value": 0,
+        "avg": 1726,
+        "min": 1726,
+        "max": 1726,
+        "percentile95th": 1726,
+        "median": 1726,
+        "empty": false
+      }, {
+        "timestamp": 1434478261167,
+        "date": "2015-06-16T18:11:01.167Z",
+        "value": 0,
+        "avg": 1866.5,
+        "min": 1796,
+        "max": 1937,
+        "percentile95th": 1937,
+        "median": 1866.5,
+        "empty": false
+      }, {
+        "timestamp": 1434478291167,
+        "date": "2015-06-16T18:11:31.167Z",
+        "value": 0,
+        "avg": 1920,
+        "min": 1920,
+        "max": 1920,
+        "percentile95th": 1920,
+        "median": 1920,
+        "empty": false
+      }, {
+        "timestamp": 1434478321167,
+        "date": "2015-06-16T18:12:01.167Z",
+        "value": 0,
+        "avg": 1737.5,
+        "min": 1695,
+        "max": 1780,
+        "percentile95th": 1780,
+        "median": 1737.5,
+        "empty": false
+      }, {
+        "timestamp": 1434478351167,
+        "date": "2015-06-16T18:12:31.167Z",
+        "value": 0,
+        "avg": 1819,
+        "min": 1819,
+        "max": 1819,
+        "percentile95th": 1819,
+        "median": 1819,
+        "empty": false
+      }, {
+        "timestamp": 1434478381167,
+        "date": "2015-06-16T18:13:01.167Z",
+        "value": 0,
+        "avg": 1859.5,
+        "min": 1680,
+        "max": 2039,
+        "percentile95th": 2039,
+        "median": 1859.5,
+        "empty": false
+      }, {
+        "timestamp": 1434478411167,
+        "date": "2015-06-16T18:13:31.167Z",
+        "value": 0,
+        "avg": 1841,
+        "min": 1841,
+        "max": 1841,
+        "percentile95th": 1841,
+        "median": 1841,
+        "empty": false
+      }, {
+        "timestamp": 1434478441167,
+        "date": "2015-06-16T18:14:01.167Z",
+        "value": 0,
+        "avg": 1754.5,
+        "min": 1731,
+        "max": 1778,
+        "percentile95th": 1778,
+        "median": 1754.5,
+        "empty": false
+      }, {
+        "timestamp": 1434478471167,
+        "date": "2015-06-16T18:14:31.167Z",
+        "value": 0,
+        "avg": 1970,
+        "min": 1970,
+        "max": 1970,
+        "percentile95th": 1970,
+        "median": 1970,
+        "empty": false
+      }, {
+        "timestamp": 1434478501167,
+        "date": "2015-06-16T18:15:01.167Z",
+        "value": 0,
+        "avg": 1663,
+        "min": 1633,
+        "max": 1693,
+        "percentile95th": 1693,
+        "median": 1663,
+        "empty": false
+      }, {
+        "timestamp": 1434478531167,
+        "date": "2015-06-16T18:15:31.167Z",
+        "value": 0,
+        "avg": 1871,
+        "min": 1871,
+        "max": 1871,
+        "percentile95th": 1871,
+        "median": 1871,
+        "empty": false
+      }, {
+        "timestamp": 1434478561167,
+        "date": "2015-06-16T18:16:01.167Z",
+        "value": 0,
+        "avg": 1827,
+        "min": 1812,
+        "max": 1842,
+        "percentile95th": 1842,
+        "median": 1827,
+        "empty": false
+      }, {
+        "timestamp": 1434478591167,
+        "date": "2015-06-16T18:16:31.167Z",
+        "value": 0,
+        "avg": 1835,
+        "min": 1835,
+        "max": 1835,
+        "percentile95th": 1835,
+        "median": 1835,
+        "empty": false
+      }, {
+        "timestamp": 1434478621167,
+        "date": "2015-06-16T18:17:01.167Z",
+        "value": 0,
+        "avg": 2011,
+        "min": 1819,
+        "max": 2203,
+        "percentile95th": 2203,
+        "median": 2011,
+        "empty": false
+      }, {
+        "timestamp": 1434478651167,
+        "date": "2015-06-16T18:17:31.167Z",
+        "value": 0,
+        "avg": 1601,
+        "min": 1601,
+        "max": 1601,
+        "percentile95th": 1601,
+        "median": 1601,
+        "empty": false
+      }, {
+        "timestamp": 1434478681167,
+        "date": "2015-06-16T18:18:01.167Z",
+        "value": 0,
+        "avg": 1793.5,
+        "min": 1686,
+        "max": 1901,
+        "percentile95th": 1901,
+        "median": 1793.5,
+        "empty": false
+      }, {
+        "timestamp": 1434478711167,
+        "date": "2015-06-16T18:18:31.167Z",
+        "value": 0,
+        "avg": 1894,
+        "min": 1894,
+        "max": 1894,
+        "percentile95th": 1894,
+        "median": 1894,
+        "empty": false
+      }, {
+        "timestamp": 1434478741167,
+        "date": "2015-06-16T18:19:01.167Z",
+        "value": 0,
+        "avg": 2126.5,
+        "min": 2005,
+        "max": 2248,
+        "percentile95th": 2248,
+        "median": 2126.5,
+        "empty": false
+      }, {
+        "timestamp": 1434478771167,
+        "date": "2015-06-16T18:19:31.167Z",
+        "value": 0,
+        "avg": 1818,
+        "min": 1818,
+        "max": 1818,
+        "percentile95th": 1818,
+        "median": 1818,
+        "empty": false
+      }, {
+        "timestamp": 1434478801167,
+        "date": "2015-06-16T18:20:01.167Z",
+        "value": 0,
+        "avg": 2005.5,
+        "min": 1854,
+        "max": 2157,
+        "percentile95th": 2157,
+        "median": 2005.5,
+        "empty": false
+      }, {
+        "timestamp": 1434478831167,
+        "date": "2015-06-16T18:20:31.167Z",
+        "value": 0,
+        "avg": 1755,
+        "min": 1755,
+        "max": 1755,
+        "percentile95th": 1755,
+        "median": 1755,
+        "empty": false
+      }, {
+        "timestamp": 1434478861167,
+        "date": "2015-06-16T18:21:01.167Z",
+        "value": 0,
+        "avg": 1746,
+        "min": 1670,
+        "max": 1822,
+        "percentile95th": 1822,
+        "median": 1746,
+        "empty": false
+      }, {
+        "timestamp": 1434478891167,
+        "date": "2015-06-16T18:21:31.167Z",
+        "value": 0,
+        "avg": 1565,
+        "min": 1565,
+        "max": 1565,
+        "percentile95th": 1565,
+        "median": 1565,
+        "empty": false
+      }, {
+        "timestamp": 1434478921167,
+        "date": "2015-06-16T18:22:01.167Z",
+        "value": 0,
+        "avg": 1742.5,
+        "min": 1645,
+        "max": 1840,
+        "percentile95th": 1840,
+        "median": 1742.5,
+        "empty": false
+      }, {
+        "timestamp": 1434478951167,
+        "date": "2015-06-16T18:22:31.167Z",
+        "value": 0,
+        "avg": 1985,
+        "min": 1985,
+        "max": 1985,
+        "percentile95th": 1985,
+        "median": 1985,
+        "empty": false
+      }, {
+        "timestamp": 1434478981167,
+        "date": "2015-06-16T18:23:01.167Z",
+        "value": 0,
+        "avg": 1669.5,
+        "min": 1591,
+        "max": 1748,
+        "percentile95th": 1748,
+        "median": 1669.5,
+        "empty": false
+      }, {
+        "timestamp": 1434479011167,
+        "date": "2015-06-16T18:23:31.167Z",
+        "value": 0,
+        "avg": 1755,
+        "min": 1755,
+        "max": 1755,
+        "percentile95th": 1755,
+        "median": 1755,
+        "empty": false
+      }, {
+        "timestamp": 1434479041167,
+        "date": "2015-06-16T18:24:01.167Z",
+        "value": 0,
+        "avg": 1963.5,
+        "min": 1950,
+        "max": 1977,
+        "percentile95th": 1977,
+        "median": 1963.5,
+        "empty": false
+      }, {
+        "timestamp": 1434479071167,
+        "date": "2015-06-16T18:24:31.167Z",
+        "value": 0,
+        "avg": 1551,
+        "min": 1551,
+        "max": 1551,
+        "percentile95th": 1551,
+        "median": 1551,
+        "empty": false
+      }, {
+        "timestamp": 1434479101167,
+        "date": "2015-06-16T18:25:01.167Z",
+        "value": 0,
+        "avg": 1768,
+        "min": 1728,
+        "max": 1808,
+        "percentile95th": 1808,
+        "median": 1768,
+        "empty": false
+      }, {
+        "timestamp": 1434479131167,
+        "date": "2015-06-16T18:25:31.167Z",
+        "value": 0,
+        "avg": 1837,
+        "min": 1837,
+        "max": 1837,
+        "percentile95th": 1837,
+        "median": 1837,
+        "empty": false
+      }, {
+        "timestamp": 1434479161167,
+        "date": "2015-06-16T18:26:01.167Z",
+        "value": 0,
+        "avg": 1700,
+        "min": 1635,
+        "max": 1765,
+        "percentile95th": 1765,
+        "median": 1700,
+        "empty": false
+      }, {
+        "timestamp": 1434479191167,
+        "date": "2015-06-16T18:26:31.167Z",
+        "value": 0,
+        "avg": 1972,
+        "min": 1972,
+        "max": 1972,
+        "percentile95th": 1972,
+        "median": 1972,
+        "empty": false
+      }, {
+        "timestamp": 1434479221167,
+        "date": "2015-06-16T18:27:01.167Z",
+        "value": 0,
+        "avg": 1666.5,
+        "min": 1592,
+        "max": 1741,
+        "percentile95th": 1741,
+        "median": 1666.5,
+        "empty": false
+      }, {
+        "timestamp": 1434479251167,
+        "date": "2015-06-16T18:27:31.167Z",
+        "value": 0,
+        "avg": 1884,
+        "min": 1884,
+        "max": 1884,
+        "percentile95th": 1884,
+        "median": 1884,
+        "empty": false
+      }, {
+        "timestamp": 1434479281167,
+        "date": "2015-06-16T18:28:01.167Z",
+        "value": 0,
+        "avg": 1695.5,
+        "min": 1634,
+        "max": 1757,
+        "percentile95th": 1757,
+        "median": 1695.5,
+        "empty": false
+      }, {
+        "timestamp": 1434479311167,
+        "date": "2015-06-16T18:28:31.167Z",
+        "value": 0,
+        "avg": 1696,
+        "min": 1696,
+        "max": 1696,
+        "percentile95th": 1696,
+        "median": 1696,
+        "empty": false
+      }, {
+        "timestamp": 1434479341167,
+        "date": "2015-06-16T18:29:01.167Z",
+        "value": 0,
+        "avg": 1929.5,
+        "min": 1829,
+        "max": 2030,
+        "percentile95th": 2030,
+        "median": 1929.5,
+        "empty": false
+      }, {
+        "timestamp": 1434479371167,
+        "date": "2015-06-16T18:29:31.167Z",
+        "value": 0,
+        "avg": 1760,
+        "min": 1760,
+        "max": 1760,
+        "percentile95th": 1760,
+        "median": 1760,
+        "empty": false
+      }, {
+        "timestamp": 1434479401167,
+        "date": "2015-06-16T18:30:01.167Z",
+        "value": 0,
+        "avg": 1637,
+        "min": 1534,
+        "max": 1740,
+        "percentile95th": 1740,
+        "median": 1637,
+        "empty": false
+      }, {
+        "timestamp": 1434479431167,
+        "date": "2015-06-16T18:30:31.167Z",
+        "value": 0,
+        "avg": 1750,
+        "min": 1750,
+        "max": 1750,
+        "percentile95th": 1750,
+        "median": 1750,
+        "empty": false
+      }, {
+        "timestamp": 1434479461167,
+        "date": "2015-06-16T18:31:01.167Z",
+        "value": 0,
+        "avg": 1874,
+        "min": 1844,
+        "max": 1904,
+        "percentile95th": 1904,
+        "median": 1874,
+        "empty": false
+      }, {
+        "timestamp": 1434479491167,
+        "date": "2015-06-16T18:31:31.167Z",
+        "value": 0,
+        "avg": 1692,
+        "min": 1692,
+        "max": 1692,
+        "percentile95th": 1692,
+        "median": 1692,
+        "empty": false
+      }, {
+        "timestamp": 1434479521167,
+        "date": "2015-06-16T18:32:01.167Z",
+        "value": 0,
+        "avg": 1797.5,
+        "min": 1781,
+        "max": 1814,
+        "percentile95th": 1814,
+        "median": 1797.5,
+        "empty": false
+      }, {
+        "timestamp": 1434479551167,
+        "date": "2015-06-16T18:32:31.167Z",
+        "value": 0,
+        "avg": 1798,
+        "min": 1798,
+        "max": 1798,
+        "percentile95th": 1798,
+        "median": 1798,
+        "empty": false
+      }, {
+        "timestamp": 1434479581167,
+        "date": "2015-06-16T18:33:01.167Z",
+        "value": 0,
+        "avg": 1875.5,
+        "min": 1827,
+        "max": 1924,
+        "percentile95th": 1924,
+        "median": 1875.5,
+        "empty": false
+      }, {
+        "timestamp": 1434479611167,
+        "date": "2015-06-16T18:33:31.167Z",
+        "value": 0,
+        "avg": 2057,
+        "min": 2057,
+        "max": 2057,
+        "percentile95th": 2057,
+        "median": 2057,
+        "empty": false
+      }, {
+        "timestamp": 1434479641167,
+        "date": "2015-06-16T18:34:01.167Z",
+        "value": 0,
+        "avg": 1759.5,
+        "min": 1552,
+        "max": 1967,
+        "percentile95th": 1967,
+        "median": 1759.5,
+        "empty": false
+      }, {
+        "timestamp": 1434479671167,
+        "date": "2015-06-16T18:34:31.167Z",
+        "value": 0,
+        "avg": 1742,
+        "min": 1742,
+        "max": 1742,
+        "percentile95th": 1742,
+        "median": 1742,
+        "empty": false
+      }, {
+        "timestamp": 1434479701167,
+        "date": "2015-06-16T18:35:01.167Z",
+        "value": 0,
+        "avg": 1872,
+        "min": 1756,
+        "max": 1988,
+        "percentile95th": 1988,
+        "median": 1872,
+        "empty": false
+      }, {
+        "timestamp": 1434479731167,
+        "date": "2015-06-16T18:35:31.167Z",
+        "value": 0,
+        "avg": 1615,
+        "min": 1615,
+        "max": 1615,
+        "percentile95th": 1615,
+        "median": 1615,
+        "empty": false
+      }, {
+        "timestamp": 1434479761167,
+        "date": "2015-06-16T18:36:01.167Z",
+        "value": 0,
+        "avg": 1714.5,
+        "min": 1635,
+        "max": 1794,
+        "percentile95th": 1794,
+        "median": 1714.5,
+        "empty": false
+      }, {
+        "timestamp": 1434479791167,
+        "date": "2015-06-16T18:36:31.167Z",
+        "value": 0,
+        "avg": 1500,
+        "min": 1500,
+        "max": 1500,
+        "percentile95th": 1500,
+        "median": 1500,
+        "empty": false
+      }, {
+        "timestamp": 1434479821167,
+        "date": "2015-06-16T18:37:01.167Z",
+        "value": 0,
+        "avg": 1781.5,
+        "min": 1745,
+        "max": 1818,
+        "percentile95th": 1818,
+        "median": 1781.5,
+        "empty": false
+      }, {
+        "timestamp": 1434479851167,
+        "date": "2015-06-16T18:37:31.167Z",
+        "value": 0,
+        "avg": 1869,
+        "min": 1869,
+        "max": 1869,
+        "percentile95th": 1869,
+        "median": 1869,
+        "empty": false
+      }, {
+        "timestamp": 1434479881167,
+        "date": "2015-06-16T18:38:01.167Z",
+        "value": 0,
+        "avg": 1724,
+        "min": 1654,
+        "max": 1794,
+        "percentile95th": 1794,
+        "median": 1724,
+        "empty": false
+      }, {
+        "timestamp": 1434479911167,
+        "date": "2015-06-16T18:38:31.167Z",
+        "value": 0,
+        "avg": 1599,
+        "min": 1599,
+        "max": 1599,
+        "percentile95th": 1599,
+        "median": 1599,
+        "empty": false
+      }, {
+        "timestamp": 1434479941167,
+        "date": "2015-06-16T18:39:01.167Z",
+        "value": 0,
+        "avg": 1912.5,
+        "min": 1833,
+        "max": 1992,
+        "percentile95th": 1992,
+        "median": 1912.5,
+        "empty": false
+      }, {
+        "timestamp": 1434479971167,
+        "date": "2015-06-16T18:39:31.167Z",
+        "value": 0,
+        "avg": 2201,
+        "min": 2201,
+        "max": 2201,
+        "percentile95th": 2201,
+        "median": 2201,
+        "empty": false
+      }, {
+        "timestamp": 1434480001167,
+        "date": "2015-06-16T18:40:01.167Z",
+        "value": 0,
+        "avg": 1855.5,
+        "min": 1701,
+        "max": 2010,
+        "percentile95th": 2010,
+        "median": 1855.5,
+        "empty": false
+      }, {
+        "timestamp": 1434480031167,
+        "date": "2015-06-16T18:40:31.167Z",
+        "value": 0,
+        "avg": 1706,
+        "min": 1706,
+        "max": 1706,
+        "percentile95th": 1706,
+        "median": 1706,
+        "empty": false
+      }, {
+        "timestamp": 1434480061167,
+        "date": "2015-06-16T18:41:01.167Z",
+        "value": 0,
+        "avg": 1863,
+        "min": 1841,
+        "max": 1885,
+        "percentile95th": 1885,
+        "median": 1863,
+        "empty": false
+      }, {
+        "timestamp": 1434480091167,
+        "date": "2015-06-16T18:41:31.167Z",
+        "value": 0,
+        "avg": 1584,
+        "min": 1584,
+        "max": 1584,
+        "percentile95th": 1584,
+        "median": 1584,
+        "empty": false
+      }, {
+        "timestamp": 1434480121167,
+        "date": "2015-06-16T18:42:01.167Z",
+        "value": 0,
+        "percentile95th": 1785,
+        "median": 1698,
+        "empty": true
+      }, {
+        "timestamp": 1434480151167,
+        "date": "2015-06-16T18:42:31.167Z",
+        "value": 0,
+        "percentile95th": 1808,
+        "median": 1808,
+        "empty": true
+      }, {
+        "timestamp": 1434480181167,
+        "date": "2015-06-16T18:43:01.167Z",
+        "value": 0,
+        "percentile95th": 1848,
+        "median": 1828,
+        "empty": true
+      }, {
+        "timestamp": 1434480211167,
+        "date": "2015-06-16T18:43:31.167Z",
+        "value": 0,
+        "percentile95th": 1857,
+        "median": 1857,
+        "empty": true
+      }, {
+        "timestamp": 1434480241167,
+        "date": "2015-06-16T18:44:01.167Z",
+        "value": 0,
+        "percentile95th": 1896,
+        "median": 1894.5,
+        "empty": true
+      }, {
+        "timestamp": 1434480271167,
+        "date": "2015-06-16T18:44:31.167Z",
+        "value": 0,
+        "avg": 2200,
+        "min": 2200,
+        "max": 2200,
+        "percentile95th": 2200,
+        "median": 2200,
+        "empty": false
+      }, {
+        "timestamp": 1434480301167,
+        "date": "2015-06-16T18:45:01.167Z",
+        "value": 0,
+        "avg": 1686.5,
+        "min": 1682,
+        "max": 1691,
+        "percentile95th": 1691,
+        "median": 1686.5,
+        "empty": false
+      }, {
+        "timestamp": 1434480331167,
+        "date": "2015-06-16T18:45:31.167Z",
+        "value": 0,
+        "avg": 1818,
+        "min": 1818,
+        "max": 1818,
+        "percentile95th": 1818,
+        "median": 1818,
+        "empty": false
+      }];
+
+
+      // this is simply a d3 function to return the beginning and ending values
+      var myTimeRange = d3.extent($scope.myData, function (value) {
+        return value.timestamp;
+      });
+      // set our initial timerange based on the data bounds
+      $scope.startTimestamp = myTimeRange[0];
+      $scope.endTimestamp = myTimeRange[1];
+      console.info('Starting time range values: ' + new Date(myTimeRange[0]) + ' - ' + new Date(myTimeRange[1]));
+
+
+      $scope.refreshChartWithDateRange = function () {
+        console.info('RefreshChart');
+        // we already have the data, but perhaps the data is stale and you want to requery
+        // also, by just changing the data the charts will automatically update themselves
+        $scope.myData = $scope.myData.filter( function (value) {
+          return value.timestamp >= $scope.startTimestamp && value.timestamp <= $scope.endTimestamp;
+        });
+       $scope.$digest();
+
+      };
+
+      $scope.$on('ChartTimeRangeChanged', function (event, data) {
+        console.info('Received ChartTimeRangeChanged: ' + data[0] + ' - ' + data[1]);
+        $scope.startTimestamp = data[0];
+        $scope.endTimestamp = data[1];
+        $scope.refreshChartWithDateRange();
+      });
+    });
+
+  </script>
+  <script src="hawkular-charts.js"></script>
+
+
+</head>
+<body ng-app="myApp">
+
+<h3>Hawkular Charts - Response Time Sample</h3>
+
+<p>
+  This page demonstrates how to use the Hawkular Charts Angular components with various configurations.
+  It uses an actual Hawkular Metrics Response Time data set captured to show how different configuration settings change
+  the look of the graph.
+</p>
+
+<p style="font-variant: all-small-caps;">
+  Feel free to change the data set or configuration settings to play around with what your chart can look like.
+</p>
+<p style="font-style: italic">
+  Also, be sure to drag on the chart to select interesting areas to zoom in on. This example has all of charts
+  responding to the change in zoom area.
+</p>
+
+<div ng-controller="ChartController">
+
+  <div class="metricIdHeader"><span class="metricIdLabel"> Chart Attributes:</span>
+    <li> alert-value="2000"</li>
+    <li> show-data-points"true"</li>
+    <li> use-zero-min-value="false" <span class="itemDescription">(Zoomed In)</span></li>
+  </div>
+  <div class="chartWrapper">
+    <hawkular-chart
+      data="myData"
+      chart-type="hawkularmetric"
+      alert-value="2000"
+      show-data-points="true"
+      y-axis-units="Response Time (ms)"
+      chart-height="250">
+    </hawkular-chart>
+  </div>
+
+  <div class="metricIdHeader"><span class="metricIdLabel"> Chart Attributes:</span>
+    <li> alert-value="2000"</li>
+    <li> use-zero-min-value="true" <span class="itemDescription">(use zero as the Y Axis)</span></li>
+  </div>
+  <div class="chartWrapper">
+    <hawkular-chart
+      data="myData"
+      chart-type="hawkularmetric"
+      alert-value="{{alertThreshold}}"
+      use-zero-min-value="true"
+      y-axis-units="Response Time (ms)"
+      chart-height="250">
+    </hawkular-chart>
+  </div>
+
+
+  <div class="metricIdHeader"><span class="metricIdLabel"> Chart Attributes:</span>
+    <li> alert-value="6000"</li>
+    <li> use-zero-min-value="true" <span class="itemDescription">(use zero as the Y Axis)</span></li>
+  </div>
+  <div class="chartWrapper">
+    <hawkular-chart
+      data="myData"
+      chart-type="hawkularmetric"
+      alert-value="6000"
+      use-zero-min-value="true"
+      y-axis-units="Response Time (ms)"
+      chart-height="250">
+    </hawkular-chart>
+  </div>
+
+  <div class="metricIdHeader"><span class="metricIdLabel"> Chart Attributes:</span>
+    <li> alert-value="1000"</li>
+    <li> use-zero-min-value="true" <span class="itemDescription">(use zero as the Y Axis)</span></li>
+  </div>
+  <div class="chartWrapper">
+    <hawkular-chart
+      data="myData"
+      chart-type="hawkularmetric"
+      alert-value="1000"
+      use-zero-min-value="true"
+      y-axis-units="Response Time (ms)"
+      chart-height="250">
+    </hawkular-chart>
+  </div>
+
+
+</div>
+
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "devDependencies": {
     "browser-sync": "^2.9.11",
     "event-stream": "3.3.2",
+    "express": "^4.13.3",
     "gulp": "3.9.0",
     "gulp-angular-templatecache": "1.8.0",
     "gulp-clean": "0.3.1",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "homepage": "https://github.com/hawkular/hawkular-charts",
   "dependencies": {},
   "devDependencies": {
+    "browser-sync": "^2.9.11",
     "event-stream": "3.3.2",
     "gulp": "3.9.0",
     "gulp-angular-templatecache": "1.8.0",


### PR DESCRIPTION
Now you can just 'gulp' or 'gulp server' and it will automatically open a browser for you with the default page up at localhost:3000. This page is live reloaded anytime there are changes to the typescript or css files. Additionally, any other other browsers that are rendering the page will also be live reloaded as well (even mobile browsers!!). Great for testing across browsers and responsive layouts. 

You can also go to other pages like 'localhost:3000/avail-test.html' and it will also live reload the changes.
