### PR TITLE
Fix bug with new forecast line not going away after zooming in on a c…

### DIFF
--- a/src/chart/metric-chart-directive.ts
+++ b/src/chart/metric-chart-directive.ts
@@ -1485,6 +1485,8 @@ namespace Charts {
                 svg.classed('selecting', !d3.event.target.empty());
                 // ignore range selections less than 1 minute
                 if (dragSelectionDelta >= 60000) {
+                  forecastDataPoints = [];
+                  showForecastData(forecastDataPoints);
                   $rootScope.$broadcast(EventNames.CHART_TIMERANGE_CHANGED.toString(), extent);
                 }
                 // clear the brush selection


### PR DESCRIPTION
…hart selection. The new chart selection still shows the forecast lines in the new chart (where it doesn't make sense). This fixes that.
