### PR TITLE
Fix Drag selection example: 

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
       background-color: #fafafa;
       border: 1px solid lightgrey;
       margin: 20px;
-      width: 840px;
+      width: 90%;
     }
 
     #alertValue {
@@ -53,12 +53,12 @@
 
     .chartWrapper {
       height: 500px;
-      width:100%;
+      width:90%;
     }
 
     .chartWrapperSmall {
       height: 100px;
-      width:100%;
+      width:90%;
     }
 
     .chartWrapperSparkline {
@@ -68,12 +68,7 @@
 
     .contextChartWrapper {
       height: 85px;
-      width: 820px;
-    }
-
-    .contextChartWrapper2 {
-      height: 85px;
-      width: 100%;
+      width: 90%;
     }
 
     .sparklineChartWrapper {
@@ -247,22 +242,12 @@
     >
     </hawkular-chart>
 
-    <!--
-    <div class="contextChartWrapper2">
-      <hawkular-context-chart
-        data="originalData"
-        show-y-axis-values="true">
-      </hawkular-context-chart>
-    </div>
-    -->
-
   </div>
 
 
   <div class="chartWrapperSmall">
     <hawkular-chart
       data="myData"
-      forecast-data="myForecastData"
       chart-type="line"
       alert-value="{{alertThreshold}}"
       show-data-points="true"
@@ -275,7 +260,6 @@
   <div class="chartWrapperSparkline">
     <hawkular-chart
       data="myData"
-      forecast-data="myForecastData"
       alert-value="{{alertThreshold}}"
       y-axis-units="Response Time (ms)"
     >

--- a/metrics-chart-sample.html
+++ b/metrics-chart-sample.html
@@ -123,45 +123,50 @@
     <li> show-data-points"true"</li>
     <li> use-zero-min-value="false" <span class="itemDescription">(Zoomed In)</span></li>
   </div>-->
+  <h4>Zoomed In</h4>
   <div class="chartWrapper">
     <hawkular-chart
       data="myData"
-      chart-type="hawkularmetric"
+      chart-type="line"
       alert-value="2000"
       show-data-points="true"
-      y-axis-units="Response Time (ms)"
-      chart-height="250">
+      y-axis-units="Response Time (ms)">
     </hawkular-chart>
   </div>
+  <p>The default behaviour is to find the high/low in the data and offset that with some space to provide a detailed
+    zoomed in effect by default.
+  </p>
 <!--
   <div class="metricIdHeader"><span class="metricIdLabel"> Chart Attributes:</span>
     <li> alert-value="2000"</li>
     <li> use-zero-min-value="true" <span class="itemDescription">(use zero as the Y Axis)</span></li>
   </div>-->
+  <h4>Use Zero as Y Axis start - Alert at 2000</h4>
   <div class="chartWrapper">
     <hawkular-chart
       data="myData"
-      chart-type="hawkularmetric"
+      chart-type="line"
       alert-value="{{alertThreshold}}"
       use-zero-min-value="true"
-      y-axis-units="Response Time (ms)"
-      chart-height="250">
+      y-axis-units="Response Time (ms)" >
     </hawkular-chart>
   </div>
+  <p>Some data is best viewed with a zero-axis starting point. Like percents, for instance.
+  </p>
 
 
  <!-- <div class="metricIdHeader"><span class="metricIdLabel"> Chart Attributes:</span>
     <li> alert-value="6000"</li>
     <li> use-zero-min-value="true" <span class="itemDescription">(use zero as the Y Axis)</span></li>
   </div>-->
+  <h4>Alert at 6000</h4>
   <div class="chartWrapper">
     <hawkular-chart
       data="myData"
-      chart-type="hawkularmetric"
+      chart-type="line"
       alert-value="6000"
       use-zero-min-value="true"
-      y-axis-units="Response Time (ms)"
-      chart-height="250">
+      y-axis-units="Response Time (ms)">
     </hawkular-chart>
   </div>
 
@@ -169,14 +174,15 @@
     <li> alert-value="1000"</li>
     <li> use-zero-min-value="true" <span class="itemDescription">(use zero as the Y Axis)</span></li>
   </div>-->
+  <h4>Alert at 1000</h4>
   <div class="chartWrapper">
     <hawkular-chart
       data="myData"
-      chart-type="hawkularmetric"
+      chart-type="line"
       alert-value="1000"
       use-zero-min-value="true"
       y-axis-units="Response Time (ms)"
-      chart-height="250">
+      >
     </hawkular-chart>
   </div>
 


### PR DESCRIPTION
Adjust the index.html example to remove the predictive values on dependent charts. This is application handling logic not chart library logic.
