### PR TITLE
Updating browser-sync to 2.12.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "babel-core": "6.7.2",
     "babel-preset-es2015": "6.6.0",
     "bootstrap": "3.3.6",
-    "browser-sync": "2.11.1",
+    "browser-sync": "^2.12.3",
     "del": "2.2.0",
     "event-stream": "3.3.2",
     "express": "4.13.4",


### PR DESCRIPTION
Please update [browser-sync](https://npmjs.org/package/browser-sync) to version 2.12.3.

If this passes your tests you can merge it in.  If not please use this branch for changes.
- [`f1baae1`](https://github.com/BrowserSync/browser-sync/commit/f1baae1082e12e18fa5deb7ddc413e388f302d3d) `2.12.3`
- [`f100ef1`](https://github.com/BrowserSync/browser-sync/commit/f100ef19cb9bd8b60bec01f18329000b01fdd44a) `fix(server-routes): ignore all falsey values - fix&hellip;`
- [`6cb750b`](https://github.com/BrowserSync/browser-sync/commit/6cb750b14a46a7f0687cc58897cc40b238a1cf15) `2.12.2`
- [`c048a1c`](https://github.com/BrowserSync/browser-sync/commit/c048a1c298a49f6c5ba9423e2be1e813fb037933) `fix(snippet): revert changes to snippet injection &hellip;`
- [`5405888`](https://github.com/BrowserSync/browser-sync/commit/5405888f95a9ffcf744aab96d46fef301cd3b784) `docs: Add new options for doc generation`
- [`24206ca`](https://github.com/BrowserSync/browser-sync/commit/24206caa0fa4957af7031d8de4a1435098aa3beb) `2.12.1`
- [`5f9423c`](https://github.com/BrowserSync/browser-sync/commit/5f9423c71b8a56557002b523f0e04bc8d4c5fca8) `fix(cli): add shebang`
- [`e1babca`](https://github.com/BrowserSync/browser-sync/commit/e1babca881e982e7383ef406f292164ae80f2c35) `2.12.0`
- [`10c7720`](https://github.com/BrowserSync/browser-sync/commit/10c7720509e4315ad48a5e3fc02945b763b95495) `deps: bump lodash, yargs, micromatch, chokidar`
- [`308b76c`](https://github.com/BrowserSync/browser-sync/commit/308b76cb8bd78cd2a1db9483bdb481fa0dbd87af) `bump brower-sync-ui to inherit fixes for #802 #931`
- [`6c95765`](https://github.com/BrowserSync/browser-sync/commit/6c957657ae37544ff1d5c54f77349f9b6b2e2aba) `tests: plugins: add tests for incorrectly configur&hellip;`
- [`8113649`](https://github.com/BrowserSync/browser-sync/commit/81136497e42b83ed99b977c2f9dee0ae1a23519d) `[wip] - adding support for plugin errors`
- [`f0ac65f`](https://github.com/BrowserSync/browser-sync/commit/f0ac65f7078babfd4b333293df984b3c89bc7d28) `fix(proxy): fail when second port scanner (when pr&hellip;`
- [`c85195d`](https://github.com/BrowserSync/browser-sync/commit/c85195dea1cdbbf85a1ff699024001f97a6d7eb9) `chore: remove redundant 'bs.app' check`
- [`decb092`](https://github.com/BrowserSync/browser-sync/commit/decb0921e16cacde962f305434d6e656d8da5101) `tests: ensure second call to getPorts (when proxy.&hellip;`

See the full [change log](https://github.com/browsersync/browser-sync/compare/49786e35d603408948217ff4e166ccb1a0059cbf...f1baae1082e12e18fa5deb7ddc413e388f302d3d) for everything that changed in this release.
